### PR TITLE
Fix/desktop/exercise btn spacing

### DIFF
--- a/lib/fitness_page.dart
+++ b/lib/fitness_page.dart
@@ -89,11 +89,11 @@ class _FitnessPage extends State<FitnessPage> {
                 )
               ),
               Padding(
-                  padding: EdgeInsets.zero,
-                  child: ElevatedButton(
-                      onPressed: logRows,
-                      child: Text('Log Set')
-                  )
+                padding: EdgeInsets.only(top: 10),
+                child: ElevatedButton(
+                  onPressed: logRows,
+                  child: Text('Log Set')
+                )
               ),
             ]
           )


### PR DESCRIPTION
Added deliberate padding between add set and log set buttons on exercise page
closes #38 